### PR TITLE
Reserve() SDK implementation (#891)

### DIFF
--- a/sdks/go/sdk.go
+++ b/sdks/go/sdk.go
@@ -79,6 +79,14 @@ func (s *SDK) Shutdown() error {
 	return errors.Wrapf(err, "could not send Shutdown message")
 }
 
+// Reserve marks the Game Server as Reserved for a given duration, at which point
+// it will return the GameServer to a Ready state.
+// Do note, the smallest unit available in the time.Duration argument is a second.
+func (s *SDK) Reserve(d time.Duration) error {
+	_, err := s.client.Reserve(s.ctx, &sdk.Duration{Seconds: int64(d.Seconds())})
+	return errors.Wrap(err, "could not send Reserve message")
+}
+
 // Health sends a ping to the health
 // check to indicate that this server is healthy
 func (s *SDK) Health() error {

--- a/sdks/go/sdk_test.go
+++ b/sdks/go/sdk_test.go
@@ -45,6 +45,10 @@ func TestSDK(t *testing.T) {
 	assert.True(t, sm.ready)
 	assert.False(t, sm.shutdown)
 
+	err = s.Reserve(12 * time.Second)
+	assert.NoError(t, err)
+	assert.EqualValues(t, 12, sm.reserved.Seconds)
+
 	err = s.Health()
 	assert.Nil(t, err)
 	assert.True(t, sm.hm.healthy)

--- a/site/content/en/docs/Guides/Client SDKs/_index.md
+++ b/site/content/en/docs/Guides/Client SDKs/_index.md
@@ -123,6 +123,25 @@ For those scenarios, this SDK functionality exists.
 as it gives Agones control over how packed `GameServers` are scheduled within a cluster, whereas with `Allocate()` you
 relinquish control to an external service which likely doesn't have as much information as Agones.
 
+{{% feature publishVersion="0.12.0" %}}
+### Reserve(seconds)
+
+With some matchmaking scenarios and systems it is important to be able to ensure that a `GameServer` is unable to be deleted,
+but doesn't trigger a FleetAutoscaler scale up. This is where `Reserve(seconds)` is useful.
+
+`Reserve(seconds)` will move the `GameServer` into the Reserved state for the specified number of seconds (0 is forever), and then it will be
+moved back to `Ready` state. While in `Reserved` state, the `GameServer` will not be deleted on scale down or `Fleet` update,
+and also will not be Allocated.
+
+This is often used when a game server process must register itself with an external system, such as a matchmaker,
+that requires it to designate itself as available for a game session for a certain period. Once a game session has started,
+it should call `SDK.Allocate()` to designate that players are currently active on it.
+
+Calling other state changing SDK commands such as `Ready` or `Allocate` will turn off the timer to reset the `GameServer` back
+to the `Ready` state.
+
+{{% /feature %}}
+
 ## Writing your own SDK
 
 If there isn't an SDK for the language and platform you are looking for, you have several options:


### PR DESCRIPTION
* Reserve() SDK implementation

This implements Reserve, with an implementation with the Go SDK.

It was also convenience to switch Allocate back to the standard async
implementation here, so that all the SDK commands are consistent in
their concurrency patterns.

Still to come:
- e2e tests
- sdk conformance test
- updates to gameserver lifecycle documentation